### PR TITLE
Fix cart.json route bug

### DIFF
--- a/Resources/app/storefront/src/plugins/cart-insight-handler.plugin.js
+++ b/Resources/app/storefront/src/plugins/cart-insight-handler.plugin.js
@@ -35,7 +35,7 @@ export default class CartInsightHandlerPlugin extends Plugin {
     }
 
     getCart() {
-        this._client.get('/checkout/cart.json', (response) => {
+        this._client.get(window.router['frontend.checkout.cart.json'], (response) => {
             const cart = JSON.parse(response);
             if (cart.lineItems.length || window.cartPreviouslyHadItems) {
                 this.handleData(cart);

--- a/Resources/views/storefront/layout/meta.html.twig
+++ b/Resources/views/storefront/layout/meta.html.twig
@@ -1,0 +1,9 @@
+{% sw_extends '@Storefront/storefront/layout/meta.html.twig' %}
+
+{% block layout_head_javascript_router %}
+    {{ parent() }}
+
+    <script>
+        window.router['frontend.checkout.cart.json'] = '{{ path('frontend.checkout.cart.json') }}';
+    </script>
+{% endblock %}


### PR DESCRIPTION
**Problem**
The CartInsightHandlerPlugin does not use the router to generate the path to fetch the cart data. The url to cart.json is hardcoded in the plugin. This causes the plugin not to work on Sales Channel that are not configured on the root. For example when using localized versions of the site under the same domain name. (example.com/nl, example.com/en, example.com/fr, ...)

**Fix**
Add the cart.json route to the window.routes object and use the correct URL in the javascript plugin. This method follows the Shopware best practices on how to generate and use URLs in storefront javascript.