### PR TITLE
Improve cart insight performance

### DIFF
--- a/Resources/app/storefront/src/plugins/cart-insight-handler.plugin.js
+++ b/Resources/app/storefront/src/plugins/cart-insight-handler.plugin.js
@@ -6,7 +6,15 @@ export default class CartInsightHandlerPlugin extends Plugin {
     static options = {}
 
     init() {
+        this._init();
+    }
+
+    _init(retries = 0) {
         if (typeof window.dmPt === 'undefined') {
+            if (retries < 10) {
+                setTimeout(this._init.bind(this, retries + 1), 100 * retries);
+            }
+
             return;
         }
 
@@ -15,7 +23,7 @@ export default class CartInsightHandlerPlugin extends Plugin {
 
         if (this.options.data) {
             const cartPhase = this.options.data.cart_phase;
-            if (cartPhase === 'ORDER_COMPLETE') {
+            if (cartPhase === 'ORDER_COMPLETE' || cartPhase === 'CART_INFO') {
                 this._cartInsight.init(this.options.data);
             } else {
                 this.getCart();
@@ -32,6 +40,10 @@ export default class CartInsightHandlerPlugin extends Plugin {
                 () => this.setCartPreviouslyHadItems(true)
             );
         }
+    }
+
+    update() {
+        this._init();
     }
 
     getCart() {

--- a/Resources/config/config.xml
+++ b/Resources/config/config.xml
@@ -56,5 +56,20 @@
             <name>acAllowNonSubscribers</name>
             <label>Allow abandoned cart for non-subscribed contacts</label>
         </input-field>
+
+        <input-field type="single-select">
+            <name>acInsightsMethod</name>
+            <label>Cart Insights collection method</label>
+            <options>
+                <option>
+                    <id>cart_info</id>
+                    <name>Cart Info</name>
+                </option>
+                <option>
+                    <id>cart_json</id>
+                    <name>Cart.json</name>
+                </option>
+            </options>
+        </input-field>
     </card>
 </config>

--- a/Resources/views/storefront/base.html.twig
+++ b/Resources/views/storefront/base.html.twig
@@ -35,6 +35,8 @@
     {# Identify guests onBlur #}
     <template data-identify-plugin></template>
 
-    {% sw_include '@DotdigitalForShopware/storefront/component/cart-insight.html.twig' %}
+    {% if config('DotdigitalForShopware.config.acInsightsMethod') == 'cart_json' %}
+        {% sw_include '@DotdigitalForShopware/storefront/component/cart-insight.html.twig' %}
+    {% endif %}
     {% sw_include '@DotdigitalForShopware/storefront/component/site-roi-tracking.html.twig' %}
 {% endblock %}

--- a/Resources/views/storefront/component/cart-insight.html.twig
+++ b/Resources/views/storefront/component/cart-insight.html.twig
@@ -8,7 +8,6 @@
 {% set canSendCartInsight = hasCorrectConfig and canSendToCurrentUser %}
 
 {% if canSendCartInsight %}
-
     {% set payloadData = {
         customer_email: context.customer.email | default(''),
         program_id: config('DotdigitalForShopware.config.acProgramId'),
@@ -51,6 +50,7 @@
                     image_url: lineItem.cover.url,
                     product_url: seoUrl('frontend.detail.page', { productId: lineItem.productId ?? lineItem.referencedId })
                 } %}
+
                 {% set processedLineItems = processedLineItems|merge([productData]) %}
             {% endif %}
         {% endfor %}
@@ -82,6 +82,7 @@
         data: payloadData
     } %}
 
-    <template data-cart-insight-handler-plugin data-cart-insight-handler-plugin-options='{{ cartInsightHandlerPluginOptions|json_encode }}'></template>
-
+    {% block cart_insight_handler_plugin_element %}
+        <template data-cart-insight-handler-plugin data-cart-insight-handler-plugin-options='{{ cartInsightHandlerPluginOptions|json_encode }}'></template>
+    {% endblock %}
 {% endif %}

--- a/Resources/views/storefront/component/cart-insight.html.twig
+++ b/Resources/views/storefront/component/cart-insight.html.twig
@@ -18,10 +18,14 @@
         cart_phase: cartPhase
     } %}
 
-    {% if cartPhase == 'ORDER_COMPLETE' %}
+    {% if cartPhase == 'CART_INFO' %}
+        {% set cartObject = page.cart %}
+    {% elseif cartPhase == 'ORDER_COMPLETE' %}
         {% set payloadData = payloadData|merge({cart_delay:0}) %}
         {% set cartObject = page.order %}
+    {% endif %}
 
+    {% if cartObject is not null %}
         {# process line items to build product payload and calculate discount #}
         {% set discountTotal = 0 %}
         {% set processedLineItems = [] %}
@@ -45,7 +49,7 @@
                     sale_price: lineItem.price.unitPrice,
                     total_price: lineItem.price.totalPrice,
                     image_url: lineItem.cover.url,
-                    product_url: seoUrl('frontend.detail.page', { productId: lineItem.productId })
+                    product_url: seoUrl('frontend.detail.page', { productId: lineItem.productId ?? lineItem.referencedId })
                 } %}
                 {% set processedLineItems = processedLineItems|merge([productData]) %}
             {% endif %}
@@ -64,7 +68,7 @@
         {% endfor %}
 
         {% set payloadData = payloadData|merge({
-            cart_id: page.order.orderNumber,
+            cart_id: cartObject.orderNumber ?? cartObject.token ?? '',
             subtotal: cartObject.price.netPrice | default(0),
             shipping: shippingTotal,
             discount_amount: discountTotal,
@@ -72,7 +76,6 @@
             grand_total: cartObject.price.totalPrice | default(0),
             line_items: processedLineItems
         }) %}
-
     {% endif %}
 
     {% set cartInsightHandlerPluginOptions = {

--- a/Resources/views/storefront/layout/header/actions/cart-widget.html.twig
+++ b/Resources/views/storefront/layout/header/actions/cart-widget.html.twig
@@ -1,0 +1,9 @@
+{% sw_extends '@Storefront/storefront/layout/header/actions/cart-widget.html.twig' %}
+
+{% block layout_header_actions_cart_widget %}
+    {{ parent() }}
+
+    {% if config('DotdigitalForShopware.config.acInsightsMethod') == 'cart_info' %}
+        {% sw_include '@DotdigitalForShopware/storefront/component/cart-insight.html.twig' with {param_cart_phase: 'CART_INFO'} %}
+    {% endif %}
+{% endblock %}


### PR DESCRIPTION
Currently the Cart Insights will load the cart.json endpoint on every pageview. This means that an additional JSON request is sent for every pageload, which might slow down the experience on slower connections, and might slow down the server in high traffic scenarios. 

Shopware by default already loads the 'Cart info widget' on every pageview. This widget also has the cart info available. By loading the Cart Insights inside this widget, it will push the correct state (cart insights & identification) to DotDigital, without the need of seperatly loading the cart.json endpoint.

It is possible that, due to custom theme changes, this might not work for some customer. For this I have added a configuration option so the user is able to choose between the two methods. The Cart Info-way will be better for performance, but the cart.json will work stabile on every system, even when the theme is overwriting the widget completely.